### PR TITLE
Bugfix - Clear card click handler

### DIFF
--- a/js/PK_test.js
+++ b/js/PK_test.js
@@ -780,6 +780,7 @@ function init() {
         card.draggable('disable')
                 .draggable('option', 'revertDuration', 0)
                 .position({within: slot, my: 'left top', at: 'left top'});
+        card.off('click', handleCardClick);
 
         // Mark the card correct or incorrect
         if ( slotNumber !== cardNumber ) {


### PR DESCRIPTION
Remove click handler on cards placed in slots, to fix bug allowing cards to be moved when placed